### PR TITLE
修复 README 中失效的 Star History 图表

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -187,11 +187,11 @@ This is the current localization of the project on Crowdin:
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=OpenStarlight%2FStarlightGUI&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OpenStarlight/StarlightGUI&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
  </picture>
 </a>
 

--- a/README.md
+++ b/README.md
@@ -187,11 +187,11 @@ Starlight GUI 是一个基于 C++/WinRT 的 WinUI3 开源项目，为开发者�
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=OpenStarlight%2FStarlightGUI&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#OpenStarlight/StarlightGUI&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/image?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=OpenStarlight/StarlightGUI&type=date&legend=top-left" />
  </picture>
 </a>
 


### PR DESCRIPTION
当前 README 中的 Star History 图表因 GitHub API 限制已经无法正常显示，这对项目宣传影响很大。本次将图表切换至可正常工作的服务，并更新了对应的链接，使星标历史图表可以重新正常展示。